### PR TITLE
[Fix] Limit versions to binaries to ensure alignment

### DIFF
--- a/packages/astcenc/package.json
+++ b/packages/astcenc/package.json
@@ -20,9 +20,9 @@
     "resolve-bin": "^1.0.1"
   },
   "optionalDependencies": {
-    "@astcenc/darwin-arm64": "^4.3.1-6",
-    "@astcenc/darwin-x64": "^4.3.1-6",
-    "@astcenc/linux-x64": "^4.3.1-6"
+    "@astcenc/darwin-arm64": ">=4.3.1-6 <4.3.2",
+    "@astcenc/darwin-x64": ">=4.3.1-6 <4.3.2",
+    "@astcenc/linux-x64": "^>=4.3.1-6 <4.3.2"
   },
   "devDependencies": {
     "@types/node": "^18.11.18"

--- a/packages/astcenc/package.json
+++ b/packages/astcenc/package.json
@@ -22,7 +22,7 @@
   "optionalDependencies": {
     "@astcenc/darwin-arm64": ">=4.3.1-6 <4.3.2",
     "@astcenc/darwin-x64": ">=4.3.1-6 <4.3.2",
-    "@astcenc/linux-x64": "^>=4.3.1-6 <4.3.2"
+    "@astcenc/linux-x64": ">=4.3.1-6 <4.3.2"
   },
   "devDependencies": {
     "@types/node": "^18.11.18"


### PR DESCRIPTION
## Reason for change
The `optionalDependencies` declaration in `astcenc/package.json` refer to the binaries in `@astcenc/*` loosely, pegged to the major version. This means that future installs could pull in minor updates to the binaries when an exact version is specified by the consumer.

## Change
Limit the binary dependency definitions to the patch version specified. Rather than specify exact versions, I did a range setup, which allows for potential future revisions of the binaries not to require changes here. Happy to make them exact if that is preferred, though.